### PR TITLE
compatible ruby 2.4, Fix an attribute name error

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ Backup::Model.new(:foo, 'Description for foo') do
 
   # 配置 Qiniu 作为备份存储方式
   store_with "Qiniu" do |qiniu|
-    qiniu.access_key_id = 'my_access_id'
+    qiniu.access_key = 'my_access_id'
     qiniu.access_key_secret = 'my_access_key'
     qiniu.bucket = 'bucket-name'
     qiniu.path = '/path/to/my/backups'

--- a/backup_qiniu.gemspec
+++ b/backup_qiniu.gemspec
@@ -17,7 +17,7 @@ Gem::Specification.new do |spec|
   spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
   spec.require_paths = ["lib"]
 
-  spec.add_dependency "backup", ">= 4.0.0"
-  spec.add_dependency "qiniu", ">= 6.2.0"
+  spec.add_dependency "backup", ">= 5.0.0.beta.1"
+  spec.add_dependency "qiniu", ">= 6.9.0"
 
 end


### PR DESCRIPTION
修改backup和qiniu两个gem的版本以兼容ruby2.4（ruby2.4下gem install会出现问题）。更改readme的一个键值，从qiniu.access_key_id改成qiniu.access_key